### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# CocktailJoker
+
+A small web app that helps calculate cocktail margins and exports them to a Google Sheets backend.
+
+## Mobile optimisation
+
+This release focuses on responsive layout without altering how data is saved to Google Sheets.
+
+- Added `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">` for proper scaling.
+- Main content is wrapped in a `max-w-screen-sm mx-auto px-4` container.
+- Buttons expand to full width on small screens while inputs break onto new lines.
+- Ingredient and summary tables scroll horizontally if the screen is too narrow.

--- a/index.html
+++ b/index.html
@@ -4,32 +4,36 @@
 <head>
   <meta charset="UTF-8">
   <title>Optimisateur de Marges de Cocktails</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 
-<body class="bg-gray-100 text-gray-800 p-4 md:p-8">
+<body class="bg-gray-100 text-gray-800">
+
+  <div class="max-w-screen-sm mx-auto px-4 py-4 md:py-8">
 
   <!-- Cocktail list buttons will mount here -->
-  <div id="cocktail-list" class="container mx-auto max-w-4xl mb-8"></div>
+  <div id="cocktail-list" class="mb-8"></div>
 
   <!-- Selected cocktails & cost analysis will mount here -->
-  <div id="selected-cocktails" class="container mx-auto max-w-4xl mb-8"></div>
+  <div id="selected-cocktails" class="mb-8"></div>
 
   <!-- Generate summary button -->
   <div class="text-center my-8">
     <button onclick="generateMenu()"
-      class="bg-indigo-600 text-white font-bold px-6 py-3 rounded-lg shadow-md hover:bg-indigo-700">
+      <!-- Full-width button on mobile -->
+      class="w-full sm:w-auto bg-indigo-600 text-white font-bold px-6 py-3 rounded-lg shadow-md hover:bg-indigo-700">
       Générer le Résumé du Menu
     </button>
   </div>
 
   <!-- Summary table will mount here -->
-  <div id="menu-summary" class="container mx-auto max-w-4xl"></div>
+  <div id="menu-summary"></div>
 
   <!-- Export (save & WhatsApp) button -->
   <div id="export-section" class="text-center mb-8 mt-4">
-    <button onclick="exportMenu()" class="bg-green-500 hover:bg-green-600 text-white font-bold px-6 py-3 rounded-lg transition-colors duration-200">
+    <!-- Full-width button on mobile -->
+    <button onclick="exportMenu()" class="w-full sm:w-auto bg-green-500 hover:bg-green-600 text-white font-bold px-6 py-3 rounded-lg transition-colors duration-200">
       Sauvegarder Votre Menu et Marges
     </button>
   </div>
@@ -37,6 +41,8 @@
   <!-- Data definitions, then app logic -->
   <script src="data.js"></script>
   <script src="logic.js"></script>
+
+  </div> <!-- /wrapper -->
 
 </body>
 

--- a/logic.js
+++ b/logic.js
@@ -94,11 +94,12 @@ function renderSelected() {
     return `
       <div class="bg-white rounded-lg p-4 mb-4 border">
         <div class="flex justify-between items-center mb-3">
-          <h3 class="text-lg font-semibold">${c.name}</h3>
+          <h3 class="text-lg font-semibold break-words">${c.name}</h3>
           <button onclick="removeCocktail(${i})" class="text-red-500">×</button>
         </div>
 
-        <div class="mb-3">
+        <div class="mb-3 overflow-x-auto">
+          <!-- Enable horizontal scrolling on small screens -->
           <div class="grid grid-cols-11 gap-2 mb-1 text-xs text-gray-500">
             <div class="col-span-1"></div>
             <div class="col-span-4">Ingrédient</div>
@@ -162,25 +163,25 @@ function renderSelected() {
           <button onclick="addNewIngredient(${i})" class="mt-2 text-sm text-blue-500 hover:text-blue-700">+ Ajouter un ingrédient</button>
         </div>
 
-        <div class="grid grid-cols-2 gap-4 mt-3">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-3">
           <div>
             <div class="text-xs text-gray-500 mb-1">Prix de vente (FCFA)</div>
             <div class="flex items-center">
-              <input type="number" 
-                     value="${c.price}" 
-                     onchange="updateCocktailPrice(${i}, parseInt(this.value))" 
-                     class="w-24 p-1 border-b">
+              <input type="number"
+                     value="${c.price}"
+                     onchange="updateCocktailPrice(${i}, parseInt(this.value))"
+                     class="w-full p-1 border-b">
             </div>
           </div>
 
           <div>
             <div class="text-xs text-gray-500 mb-1">Popularité (1-5)</div>
-            <input type="number" 
-                   min="1" 
-                   max="5" 
-                   value="${c.popularity}" 
-                   onchange="updateCocktailPopularity(${i}, parseInt(this.value))" 
-                   class="w-16 p-1 border-b">
+              <input type="number"
+                   min="1"
+                   max="5"
+                   value="${c.popularity}"
+                   onchange="updateCocktailPopularity(${i}, parseInt(this.value))"
+                   class="w-full p-1 border-b">
           </div>
         </div>
 
@@ -455,6 +456,7 @@ function generateMenu() {
     </div>
     
     <div class="overflow-x-auto">
+    <!-- Scroll horizontally on small screens -->
       <table class="min-w-full bg-white rounded-lg overflow-hidden">
         <thead class="bg-gray-50">
           <tr>
@@ -470,7 +472,7 @@ function generateMenu() {
                               cocktail.margin >= 75 ? 'text-green-600' : 'text-red-600';
             return `
             <tr class="hover:bg-gray-50">
-              <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">${cocktail.name}</td>
+              <td class="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900 break-words">${cocktail.name}</td>
               <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-700">${Math.round(cocktail.price)} FCFA</td>
               <td class="px-4 py-3 whitespace-nowrap text-sm font-medium ${marginColor}">
                 ${Math.round(cocktail.margin)}%


### PR DESCRIPTION
## Summary
- add viewport meta maximum scale
- wrap page content in a responsive container
- simplify per-section containers
- break words on long names and tables
- make price and popularity inputs full width
- adjust ingredient forms to stack on small screens

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684b0b8739ac8332baa9a706a014863d