### PR TITLE
Add custom cocktail creation

### DIFF
--- a/__tests__/logic.test.js
+++ b/__tests__/logic.test.js
@@ -1,5 +1,11 @@
 /** @jest-environment jsdom */
-const { calcTotalCost, generateMenu, __setSelected } = require('../logic.js');
+const {
+  calcTotalCost,
+  generateMenu,
+  __setSelected,
+  renderSelected,
+  addCustomCocktail
+} = require('../logic.js');
 
 describe('calcTotalCost', () => {
   beforeEach(() => {
@@ -88,4 +94,19 @@ describe('index.html inputs', () => {
     expect(weekend.type).toBe('number');
     expect(weekday.type).toBe('number');
   });
+});
+
+test('New custom cocktail appears on click', () => {
+  document.body.innerHTML = '<div id="cocktail-list"></div><div id="selected-cocktails"></div><div id="menu-summary"></div>';
+  __setSelected([]);
+  global.cocktails = [];
+  addCustomCocktail();
+  const name = document.querySelector('#selected-cocktails h3').textContent;
+  expect(name).toBe('Nouveau cocktail');
+});
+
+test('Rendering empty ingredients doesn\'t crash', () => {
+  document.body.innerHTML = '<div id="selected-cocktails"></div><div id="menu-summary"></div>';
+  __setSelected([{ name: 'Test', price: 1000, popularity: 3, ingredients: [{ name: '', volume: 0 }] }]);
+  expect(() => renderSelected()).not.toThrow();
 });

--- a/logic.js
+++ b/logic.js
@@ -17,6 +17,24 @@ function addCocktail(name) {
   }
 }
 
+// Add a blank custom cocktail for the user to fill in
+function addCustomCocktail() {
+  const newCocktail = {
+    name: "Nouveau cocktail",
+    price: 0,
+    popularity: 3,
+    ingredients: [
+      { name: "", volume: 0 },
+      { name: "", volume: 0 },
+      { name: "", volume: 0 }
+    ]
+  };
+
+  selected.push(newCocktail);
+  renderSelected();
+  renderCocktailList();
+}
+
 // Renders the initial list of cocktail buttons
 function renderCocktailList() {
   const div = document.getElementById("cocktail-list");
@@ -68,6 +86,13 @@ function renderCocktailList() {
   if (cocktails.some(c => c.popularity < 4)) {
     div.appendChild(toggleButton);
   }
+
+  // Button to let the user create a brand new cocktail
+  const createBtn = document.createElement('button');
+  createBtn.className = 'bg-green-500 text-white font-bold py-2 px-4 rounded-md m-1 hover:bg-green-600';
+  createBtn.textContent = '+ Créer un cocktail';
+  createBtn.onclick = () => addCustomCocktail();
+  div.appendChild(createBtn);
 }
 
 // Renders the cards for each selected cocktail
@@ -666,7 +691,9 @@ if (typeof module !== 'undefined') {
     calcTotalCost,
     generateMenu,
     __setSelected: s => { selected = s; },
-    renderCocktailList
+    renderCocktailList,
+    renderSelected,
+    addCustomCocktail
   };
 }
 


### PR DESCRIPTION
## Summary
- support user-created cocktails with `addCustomCocktail`
- add a UI button in cocktail list to create one
- export helper functions for testing
- test custom cocktail creation and rendering with blank ingredients

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c78197d348332abbec93ee1ff51a6